### PR TITLE
layer.conf: fix warning of LAYERSERIES_COMPAT

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 #   Name/Organization <email address>
 
 Sony Group Corporation
+Phong Tran <tranmanphong@gmail.com>

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,5 @@ BBFILE_COLLECTIONS += "meta-flutter"
 BBFILE_PATTERN_meta-flutter = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-flutter = "6"
 
+LAYERSERIES_COMPAT_meta-flutter = "dunfell"
 LAYERDEPENDS_meta-flutter = "core"


### PR DESCRIPTION
Adding the config for making clear support oe version as [1]

WARNING: Layer meta-flutter should set LAYERSERIES_COMPAT_meta-flutter
in its conf/layer.conf file to list the core layer names it is compatible with.

[1] https://www.yoctoproject.org/docs/3.1/ref-manual/ref-manual.html#var-LAYERSERIES_COMPAT

Signed-off-by: Phong Tran <tranmanphong@gmail.com>