### PR TITLE
Fix xcb.h not found while compiling flutter-engine

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine.bb
@@ -10,7 +10,7 @@ inherit pkgconfig
 # TODO: Add dependent packages.
 DEPENDS = "freetype \
            curl-native ca-certificates-native depot-tools-native \
-           wayland wayland-protocols wayland-native"
+           wayland wayland-protocols wayland-native cairo"
 
 GN_TOOLS_PYTHON2_PATH ??= "bootstrap-2@3.8.10.chromium.23_bin/python/bin"
 


### PR DESCRIPTION
While compiling flutter-engine using Bitbake, Ninja throws an error saying 'file not found: xcb.h' because the file is missing from the recipe's sysroot. Adding Cairo as a build time dependency fixes this issue since Caire provides the file.

It seems the recent Flutter engine version now depend on this file.
